### PR TITLE
The сlientId type can be a number.

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -41,7 +41,7 @@ export type ClientOptions = {
   /**
    * User ID. Pass `false` if no user.
    */
-  userId: string | false
+  userId: number | string | false
 
   /**
    * Client credentials for authentication.


### PR DESCRIPTION
The `clientId` type == `string | false`, but users can use number. You use number [in `@logux/redux` tests](https://github.com/logux/redux/blob/master/create-logux-creator/index.test.js#L10), for example.

This is possible because when parameters are loaded, the userId is [attached to the string](https://github.com/logux/client/blob/master/client/index.js#L56).

To legalize using a number as a userId, I suggest adding it to the number type.