### PR TITLE
Use new undo api

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -21,7 +21,6 @@ export type LoguxUndoAction = {
   id: string
   action: Action
   reason?: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
 }
 

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -16,6 +16,15 @@ export interface ClientActionListener {
   (action: Action, meta: ClientMeta): void
 }
 
+export type LoguxUndoAction = {
+  type: 'logux/undo'
+  id: string
+  action: Action
+  reason?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
 export type ClientMeta = Meta & {
   /**
    * Action should be visible only for browser tab with the same `client.tabId`.

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -24,6 +24,10 @@ export type LoguxUndoAction = {
   [key: string]: any
 }
 
+export type LoguxUndoError = Error & {
+  action: LoguxUndoAction
+}
+
 export type ClientMeta = Meta & {
   /**
    * Action should be visible only for browser tab with the same `client.tabId`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,13 @@ export {
   BadgeMessages,
   BadgeStyles
 } from './badge/index.js'
-export { Client, ClientMeta, ClientOptions } from './client/index.js'
+export {
+  Client,
+  ClientMeta,
+  ClientOptions,
+  LoguxUndoAction,
+  LoguxUndoError
+} from './client/index.js'
 export { CrossTabClient } from './cross-tab-client/index.js'
 export { IndexedStore } from './indexed-store/index.js'
 export { attention } from './attention/index.js'

--- a/log/__snapshots__/index.test.ts.snap
+++ b/log/__snapshots__/index.test.ts.snap
@@ -23,7 +23,7 @@ exports[`prints log 1`] = `
   Action {\\"type\\":\\"A\\"}
   Meta {\\"sync\\":true,\\"id\\":\\"1 10:1:1 0\\",\\"time\\":1,\\"reasons\\":[],\\"subprotocol\\":\\"1.0.0\\",\\"added\\":1}
 [33m[1mLogux[22m[39m action [1mA[22m was undone because of [1merror[22m
-  Undone Action {\\"type\\":\\"A\\"}
+  Reverted Action {\\"type\\":\\"A\\"}
 [33m[1mLogux[22m[39m subscribing to [1musers[22m channel
 [33m[1mLogux[22m[39m state is [1msending[22m
 [33m[1mLogux[22m[39m state is [1msynchronized[22m
@@ -46,7 +46,7 @@ exports[`prints log 1`] = `
 [33m[1mLogux[22m[39m state is [1msending[22m
 [33m[1mLogux[22m[39m state is [1msynchronized[22m
 [33m[1mLogux[22m[39m subscription to [1musers[22m was undone because of [1merror[22m
-  Undone Action {\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":1}
+  Reverted Action {\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":1}
   Undo Action {\\"type\\":\\"logux/undo\\",\\"action\\":{\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":1},\\"id\\":\\"3 10:1:1 0\\",\\"reason\\":\\"error\\",\\"wrongProp\\":\\"sync\\"}
 [33m[1mLogux[22m[39m unsubscribed from channel [1musers[22m
 [33m[1mLogux[22m[39m unsubscribed from channel [1musers[22m
@@ -63,7 +63,7 @@ exports[`prints log 1`] = `
   Processed Action {\\"type\\":\\"B\\"}
 [33m[1mLogux[22m[39m action [1m200 10:1:1 0[22m was processed
 [33m[1mLogux[22m[39m action [1mB[22m was undone because of [1merror[22m
-  Undone Action {\\"type\\":\\"B\\"}
+  Reverted Action {\\"type\\":\\"B\\"}
 [33m[1mLogux[22m[39m user ID was changed to [1m20[22m
   Node ID: [1m20:2:2[22m
 "

--- a/log/__snapshots__/index.test.ts.snap
+++ b/log/__snapshots__/index.test.ts.snap
@@ -22,8 +22,8 @@ exports[`prints log 1`] = `
 [33m[1mLogux[22m[39m cleaned [1mA[22m action
   Action {\\"type\\":\\"A\\"}
   Meta {\\"sync\\":true,\\"id\\":\\"1 10:1:1 0\\",\\"time\\":1,\\"reasons\\":[],\\"subprotocol\\":\\"1.0.0\\",\\"added\\":1}
-[33m[1mLogux[22m[39m action [1m1 10:1:1 0[22m was undid because of [1merror[22m
-  Action {\\"type\\":\\"A\\"}
+[33m[1mLogux[22m[39m action [1mA[22m was undone because of [1merror[22m
+  Undone Action {\\"type\\":\\"A\\"}
 [33m[1mLogux[22m[39m subscribing to [1musers[22m channel
 [33m[1mLogux[22m[39m state is [1msending[22m
 [33m[1mLogux[22m[39m state is [1msynchronized[22m
@@ -45,9 +45,9 @@ exports[`prints log 1`] = `
   Action {\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":1}
 [33m[1mLogux[22m[39m state is [1msending[22m
 [33m[1mLogux[22m[39m state is [1msynchronized[22m
-[33m[1mLogux[22m[39m action [1m3 10:1:1 0[22m was undid because of [1merror[22m
-  Action {\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":{\\"id\\":\\"2 server:uuid 0\\",\\"time\\":2}}
-  Undo {\\"type\\":\\"logux/undo\\",\\"id\\":\\"3 10:1:1 0\\",\\"reason\\":\\"error\\",\\"wrongProp\\":\\"sync\\"}
+[33m[1mLogux[22m[39m subscription to [1musers[22m was undone because of [1merror[22m
+  Undone Action {\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":1}
+  Undo Action {\\"type\\":\\"logux/undo\\",\\"action\\":{\\"type\\":\\"logux/subscribe\\",\\"channel\\":\\"users\\",\\"since\\":1},\\"id\\":\\"3 10:1:1 0\\",\\"reason\\":\\"error\\",\\"wrongProp\\":\\"sync\\"}
 [33m[1mLogux[22m[39m unsubscribed from channel [1musers[22m
 [33m[1mLogux[22m[39m unsubscribed from channel [1musers[22m
   Action {\\"type\\":\\"logux/unsubscribe\\",\\"channel\\":\\"users\\",\\"bad\\":true}
@@ -62,7 +62,8 @@ exports[`prints log 1`] = `
 [33m[1mLogux[22m[39m action [1mB[22m was processed
   Processed Action {\\"type\\":\\"B\\"}
 [33m[1mLogux[22m[39m action [1m200 10:1:1 0[22m was processed
-[33m[1mLogux[22m[39m action [1m201 10:1:1 0[22m was undid because of [1merror[22m
+[33m[1mLogux[22m[39m action [1mB[22m was undone because of [1merror[22m
+  Undone Action {\\"type\\":\\"B\\"}
 [33m[1mLogux[22m[39m user ID was changed to [1m20[22m
   Node ID: [1m20:2:2[22m
 "

--- a/log/index.js
+++ b/log/index.js
@@ -124,7 +124,7 @@ function log (client, messages = {}) {
           }
           message += ' was undone because of ' + bold(action.reason)
           let details = {
-            'Undone Action': action.action
+            'Reverted Action': action.action
           }
           if (Object.keys(action).length > 4) {
             details['Undo Action'] = action

--- a/log/index.js
+++ b/log/index.js
@@ -117,18 +117,20 @@ function log (client, messages = {}) {
             showLog('action ' + bold(action.id) + ' was processed')
           }
         } else if (action.type === 'logux/undo') {
-          message =
-            'action ' +
-            bold(action.id) +
-            ' was undid because of ' +
-            bold(action.reason)
-          let details = {}
-          if (sent[action.id]) {
-            details.Action = sent[action.id]
-            delete sent[action.id]
+          if (action.action.type === 'logux/subscribe') {
+            message = 'subscription to ' + bold(action.action.channel)
+          } else {
+            message = 'action ' + bold(action.action.type)
           }
-          if (Object.keys(action).length > 3) {
-            details.Undo = action
+          message += ' was undone because of ' + bold(action.reason)
+          let details = {
+            'Undone Action': action.action
+          }
+          if (Object.keys(action).length > 4) {
+            details['Undo Action'] = action
+          }
+          if (sent[action.id]) {
+            delete sent[action.id]
           }
           showLog(message, details)
         } else {

--- a/log/index.test.ts
+++ b/log/index.test.ts
@@ -95,6 +95,7 @@ it('prints log', async () => {
   await client.node.log.add(
     {
       type: 'logux/undo',
+      action: { type: 'A' },
       id: '1 10:1:1 0',
       reason: 'error'
     },
@@ -135,6 +136,7 @@ it('prints log', async () => {
   await client.node.log.add(
     {
       type: 'logux/undo',
+      action: { type: 'logux/subscribe', channel: 'users', since: 1 },
       id: '3 10:1:1 0',
       reason: 'error',
       wrongProp: 'sync'
@@ -176,6 +178,7 @@ it('prints log', async () => {
   await client.node.log.add(
     {
       type: 'logux/undo',
+      action: { type: 'B' },
       id: '201 10:1:1 0',
       reason: 'error'
     },

--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
   },
   "eslintConfig": {
     "extends": "@logux/eslint-config/ts",
+    "rules": {
+      "@typescript-eslint/no-explicit-any": "off"
+    },
     "overrides": [
       {
         "files": "indexed-store/index.test.ts",


### PR DESCRIPTION
Part of logux/logux#52

- Adds `LoguxUndoAction ` and `LoguxUndoError ` types and exports its from root `index.js`.
- Improves `log` messages with new undo API:
  - more explicit undo action’s message about subscription
  - more explicit undo action’s details
- Disables `no-explicit-any` eslint rule.