### PR TITLE
Move check for non-empty client to `useClient`

### DIFF
--- a/preact/index.js
+++ b/preact/index.js
@@ -11,27 +11,18 @@ export let ClientContext = /*#__PURE__*/ createContext()
 let ErrorsContext = /*#__PURE__*/ createContext()
 
 export function useClient() {
-  return useContext(ClientContext)
+  let client = useContext(ClientContext)
+  if (process.env.NODE_ENV !== 'production' && !client) {
+    throw new Error('Wrap components in Logux <ClientContext.Provider>')
+  }
+  return client
 }
 
 function useSyncStore(store) {
   let [error, setError] = useState(null)
   let [, forceRender] = useState({})
 
-  let value
-  if (process.env.NODE_ENV === 'production') {
-    value = getValue(store)
-  } else {
-    try {
-      value = getValue(store)
-    } catch (e) {
-      if (e.message === 'Missed Logux client') {
-        throw new Error('Wrap components in Logux <ClientContext.Provider>')
-      } else {
-        throw e
-      }
-    }
-  }
+  let value = getValue(store)
 
   if (process.env.NODE_ENV !== 'production') {
     let errorProcessors = useContext(ErrorsContext) || {}

--- a/preact/index.test.ts
+++ b/preact/index.test.ts
@@ -184,6 +184,14 @@ it('throws on missed context for sync map', () => {
   expect(errors).toEqual(['Wrap components in Logux <ClientContext.Provider>'])
 })
 
+it('throws on missed context for useClient', () => {
+  let [errors, Catcher] = getCatcher(() => {
+    useClient()
+  })
+  render(h(Catcher, null))
+  expect(errors).toEqual(['Wrap components in Logux <ClientContext.Provider>'])
+})
+
 it('throws store init errors', () => {
   let Builder = defineMap(() => {
     throw new Error('Test')
@@ -191,7 +199,7 @@ it('throws store init errors', () => {
   let [errors, Catcher] = getCatcher(() => {
     useSync(Builder, 'id')
   })
-  render(h(Catcher, null))
+  runWithClient(h(Catcher, null))
   expect(errors).toEqual(['Test'])
 })
 

--- a/react/index.js
+++ b/react/index.js
@@ -11,27 +11,17 @@ export let ClientContext = /*#__PURE__*/ React.createContext()
 let ErrorsContext = /*#__PURE__*/ React.createContext()
 
 export function useClient() {
-  return React.useContext(ClientContext)
+  let client = React.useContext(ClientContext)
+  if (process.env.NODE_ENV !== 'production' && !client) {
+    throw new Error('Wrap components in Logux <ClientContext.Provider>')
+  }
+  return client
 }
 
 function useSyncStore(store) {
   let [error, setError] = React.useState(null)
   let [, forceRender] = React.useState({})
-
-  let value
-  if (process.env.NODE_ENV === 'production') {
-    value = getValue(store)
-  } else {
-    try {
-      value = getValue(store)
-    } catch (e) {
-      if (e.message === 'Missed Logux client') {
-        throw new Error('Wrap components in Logux <ClientContext.Provider>')
-      } else {
-        throw e
-      }
-    }
-  }
+  let value = getValue(store)
 
   if (process.env.NODE_ENV !== 'production') {
     let errorProcessors = React.useContext(ErrorsContext) || {}

--- a/react/index.test.ts
+++ b/react/index.test.ts
@@ -180,6 +180,14 @@ it('throws on missed context for sync map', () => {
   expect(errors).toEqual(['Wrap components in Logux <ClientContext.Provider>'])
 })
 
+it('throws on missed context for useClient', () => {
+  let [errors, Catcher] = getCatcher(() => {
+    useClient()
+  })
+  render(h(Catcher))
+  expect(errors).toEqual(['Wrap components in Logux <ClientContext.Provider>'])
+})
+
 it('throws store init errors', () => {
   let Builder = defineMap(() => {
     throw new Error('Test')
@@ -187,7 +195,7 @@ it('throws store init errors', () => {
   let [errors, Catcher] = getCatcher(() => {
     useSync(Builder, 'id')
   })
-  render(h(Catcher))
+  runWithClient(h(Catcher))
   expect(errors).toEqual(['Test'])
 })
 

--- a/vue/index.js
+++ b/vue/index.js
@@ -31,7 +31,14 @@ export function loguxPlugin(app, client) {
 }
 
 export function useClient() {
-  return inject(ClientKey)
+  let client = inject(ClientKey)
+  if (process.env.NODE_ENV !== 'production' && !client) {
+    throw new Error(
+      `Install Logux Client using loguxPlugin: ` +
+        `app.use(loguxPlugin, client).`
+    )
+  }
+  return client
 }
 
 function checkErrorProcessor() {
@@ -53,22 +60,7 @@ function useSyncStore(store) {
     triggerRef(state)
   }
 
-  if (process.env.NODE_ENV === 'production') {
-    unsubscribe = store.subscribe(listener)
-  } else {
-    try {
-      unsubscribe = store.subscribe(listener)
-    } catch (e) {
-      if (e.message === 'Missed Logux client') {
-        throw new Error(
-          `Install Logux Client using loguxPlugin: ` +
-            `app.use(loguxPlugin, client).`
-        )
-      } else {
-        throw e
-      }
-    }
-  }
+  unsubscribe = store.subscribe(listener)
 
   if (store.loading) {
     watch(error, () => {

--- a/vue/index.test.ts
+++ b/vue/index.test.ts
@@ -191,7 +191,23 @@ it('throws on missed logux client dependency', () => {
     })
   )
   expect(errors).toEqual([
-    `Install Logux Client using loguxPlugin: ` + `app.use(loguxPlugin, client).`
+    `Install Logux Client using loguxPlugin: app.use(loguxPlugin, client).`
+  ])
+  spy.mockRestore()
+})
+
+it('throws on missed logux client dependency for useClient', () => {
+  let spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  let [errors, Catcher] = getCatcher(() => {
+    useClient()
+  })
+  render(
+    h(ChannelErrors, null, {
+      default: () => h(Catcher)
+    })
+  )
+  expect(errors).toEqual([
+    `Install Logux Client using loguxPlugin: app.use(loguxPlugin, client).`
   ])
   spy.mockRestore()
 })
@@ -216,7 +232,7 @@ it('throws store init errors', () => {
   let [errors, Catcher] = getCatcher(() => {
     useSync(Builder, 'id')
   })
-  render(
+  renderWithClient(
     h(ChannelErrors, null, {
       default: () => h(Catcher)
     })


### PR DESCRIPTION
`useClient` is the main way to get client and will always be used to get `client` from context. So there are no reasons to throw this error in the other places. i.e. how would `<ClientContext.Provider>` help you if you are not using `useClient`?