### PR TITLE
feat(create-auth): async `loading` key

### DIFF
--- a/create-auth/index.d.ts
+++ b/create-auth/index.d.ts
@@ -11,7 +11,7 @@ export interface AuthStore
     isAuthenticated: boolean
   }> {
   /**
-   * While store is loading initial data from server or log.
+   * While store is loading initial state.
    */
   readonly loading: Promise<void>
 }

--- a/create-auth/index.d.ts
+++ b/create-auth/index.d.ts
@@ -5,10 +5,16 @@ import { Client } from '../client/index.js'
 /**
  * Auth store. Use {@link createAuth} to create it.
  */
-export type Auth = MapStore<{
-  userId: string
-  isAuthenticated: boolean
-}>
+export interface AuthStore
+  extends MapStore<{
+    userId: string
+    isAuthenticated: boolean
+  }> {
+  /**
+   * While store is loading initial data from server or log.
+   */
+  readonly loading: Promise<void>
+}
 
 /**
  * Create store with user’s authentication state.
@@ -18,11 +24,10 @@ export type Auth = MapStore<{
  * import { getValue } from 'nanostores'
  *
  * let auth = createAuth(client)
- * auth.subscribe(({ isAuthenticated, userId }) => {
- *   console.log(isAuthenticated, userId)
- * })
+ * await auth.loading
+ * console.log(getValue(auth))
  * ```
  *
  * @param client Logux Client.
  */
-export function createAuth(client: Client): Auth
+export function createAuth(client: Client): AuthStore

--- a/create-auth/index.js
+++ b/create-auth/index.js
@@ -6,8 +6,9 @@ export function createAuth(client) {
     auth.setKey('isAuthenticated', client.node.state === 'synchronized')
 
     let load
-    let loaded = false
+    let loaded = auth.value.isAuthenticated
     auth.loading = new Promise(resolve => {
+      if (loaded) resolve()
       load = () => {
         loaded = true
         resolve()

--- a/create-auth/index.js
+++ b/create-auth/index.js
@@ -5,6 +5,15 @@ export function createAuth(client) {
     auth.setKey('userId', client.options.userId)
     auth.setKey('isAuthenticated', client.node.state === 'synchronized')
 
+    let load
+    let loaded = false
+    auth.loading = new Promise(resolve => {
+      load = () => {
+        loaded = true
+        resolve()
+      }
+    })
+
     let stateBinded = false
     let unbindState
 
@@ -13,6 +22,7 @@ export function createAuth(client) {
       unbindState = client.node.on('state', () => {
         if (client.node.state === 'synchronized') {
           auth.setKey('isAuthenticated', true)
+          if (!loaded) load()
           unbindState()
           stateBinded = false
         }
@@ -25,6 +35,7 @@ export function createAuth(client) {
       if (error.type === 'wrong-credentials') {
         if (!stateBinded) bindState()
         auth.setKey('isAuthenticated', false)
+        if (!loaded) load()
       }
     })
     let unbindUser = client.on('user', newUserId => {

--- a/create-auth/index.test.ts
+++ b/create-auth/index.test.ts
@@ -16,7 +16,6 @@ it('returns the state of authentication', async () => {
   let client = new TestClient('10')
   let auth = createAuth(client)
 
-  auth.listen(() => {})
   expect(getValue(auth).userId).toBe('10')
   expect(getValue(auth).isAuthenticated).toBe(false)
 
@@ -24,11 +23,23 @@ it('returns the state of authentication', async () => {
   expect(getValue(auth).isAuthenticated).toBe(true)
 })
 
+it('has loading state', async () => {
+  let client = new TestClient('10')
+  client.connect()
+
+  let auth = createAuth(client)
+
+  expect(getValue(auth).userId).toBe('10')
+  expect(getValue(auth).isAuthenticated).toBe(false)
+
+  await auth.loading
+  expect(getValue(auth).isAuthenticated).toBe(true)
+})
+
 it('change state on wrong credentials', async () => {
   let client = new TestClient('10')
   let auth = createAuth(client)
 
-  auth.listen(() => {})
   await client.connect()
   expect(getValue(auth).isAuthenticated).toBe(true)
 
@@ -41,7 +52,6 @@ it('doesn’t change state on disconnection', async () => {
   let client = new TestClient('10')
   let auth = createAuth(client)
 
-  auth.listen(() => {})
   await client.connect()
   expect(getValue(auth).isAuthenticated).toBe(true)
 
@@ -54,7 +64,6 @@ it('updates user id after user change', async () => {
   let client = new TestClient('10')
   let auth = createAuth(client)
 
-  auth.listen(() => {})
   await client.connect()
   expect(getValue(auth).userId).toBe('10')
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export {
 export { Client, ClientMeta, ClientOptions } from './client/index.js'
 export { prepareForTest, emptyInTest } from './prepare-for-test/index.js'
 export { request, RequestOptions } from './request/index.js'
-export { createAuth, Auth } from './create-auth/index.js'
+export { createAuth, AuthStore } from './create-auth/index.js'
 export { encryptActions } from './encrypt-actions/index.js'
 export { CrossTabClient } from './cross-tab-client/index.js'
 export { IndexedStore } from './indexed-store/index.js'

--- a/preact/index.d.ts
+++ b/preact/index.d.ts
@@ -10,7 +10,7 @@ import {
 import { FilterOptions, FilterStore, Filter } from '../create-filter/index.js'
 import { SyncMapBuilder, SyncMapValue } from '../define-sync-map/index.js'
 import { Client } from '../client/index.js'
-import { Auth } from '../create-auth/index.js'
+import { AuthStore } from '../create-auth/index.js'
 
 /**
  * Context to send Logux Client or object space to components deep in the tree.
@@ -155,4 +155,4 @@ export function useFilter<Value extends SyncMapValues>(
  * }
  * ```
  */
-export function useAuth(): StoreValue<Auth>
+export function useAuth(): StoreValue<AuthStore>

--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -10,7 +10,7 @@ import {
 import { FilterOptions, FilterStore, Filter } from '../create-filter/index.js'
 import { SyncMapBuilder, SyncMapValue } from '../define-sync-map/index.js'
 import { Client } from '../client/index.js'
-import { Auth } from '../create-auth/index.js'
+import { AuthStore } from '../create-auth/index.js'
 
 /**
  * Context to send Logux Client or object space to components deep in the tree.
@@ -155,4 +155,4 @@ export function useFilter<Value extends SyncMapValues>(
  * }
  * ```
  */
-export function useAuth(): StoreValue<Auth>
+export function useAuth(): StoreValue<AuthStore>


### PR DESCRIPTION
Useful at the first call of router guard:
```ts
router.beforeResolve(async to => {
  let auth = createAuth(client)
  await auth.loading
  let { isAuthenticated } = getValue(auth)
  if (isAuthenticated) {
    return true
  } else {
    return '/login'
  }
})
```