### PR TITLE
Fix logger for clean events

### DIFF
--- a/log/index.js
+++ b/log/index.js
@@ -171,7 +171,7 @@ export function log(client, messages = {}) {
           delete cleaned[meta.id]
           return
         }
-        if (meta.tab && meta.tab !== client.id) return
+        if (meta.tab && meta.tab !== client.tabId) return
         if (ignore[action.type]) return
         if (action.type.startsWith('logux/')) return
         let message = 'cleaned ' + bold(action.type) + ' action'


### PR DESCRIPTION
`id` doesn't exist on a `client` object, as in the code above it seems that `tabId` should be used