### PR TITLE
fix: resubscribe on synchronize

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -256,7 +256,7 @@ export class Client {
     let disconnected = true
     this.node.on('state', () => {
       let state = this.node.state
-      if (state === 'synchronized' || state === 'sending') {
+      if (state === 'synchronized') {
         if (disconnected) {
           disconnected = false
           for (let i in this.subscriptions) {


### PR DESCRIPTION
# Context
We're using logux at https://voiceflow.com/ to enable a consistent multiplayer experience for designing conversations.
The frontend is react-redux, with the logux store. 
Our persistence layer is MongoDB and we update the document from the server based on the action through mongo's query language. This may update deeply nested fields within an object. 

# Race Condition
I noticed a bug from my repeated testing of starting and stopping the server to see how logux syncs offline actions.

From a high level this is what is happening:
* The user is offline/disconnected, they perform a large number of actions
* the user reconnects to the socket server - [this triggers `connectedMessage` which in turn calls `syncSince`](https://github.com/logux/core/blob/5cd651377f43e00cc3e5e2a2e48bab4550ab387e/connect/index.js#L144-L170).
* Since there are many offline actions to sync, `syncSince` will call `sendSync`, which in turn sends out the actions, and sets the node's state: [`this.setState('sending')`](https://github.com/logux/core/blob/5cd651377f43e00cc3e5e2a2e48bab4550ab387e/sync/index.js#L32)
* changing the node's state to `sending` causes [this block](https://github.com/logux/core/blob/5cd651377f43e00cc3e5e2a2e48bab4550ab387e/sync/index.js#L32) of `client` to trigger. (it was previously disconnected, so resubscribe to the channels). This effectively sends out the `logux/subscribe` action right as all the sync messages from `syncSince` are being sent.
* on the server, it processes all the messages with the [`syncMessage`](https://github.com/logux/core/blob/5cd651377f43e00cc3e5e2a2e48bab4550ab387e/sync/index.js#L40) function. This executes them as a sequence of promises with `options.inMap` potentially delaying execution before the action is added to the log and processed.

This is all fairly stochastic. TCP should ensure the websocket messages are sent in order, but the server itself might only partially process the `syncMessage` before processing the resubscribe (`logux/subscribe`)

This means it is possible for the [channel's `load` function](https://github.com/logux/server/blob/95166cee9c1da9184a827ed72f343b76be99e021/base-server/index.js#L767), which should send back the latest state with all the changes, to send back a state without the offline sync messages, or a partial amount. 
This is especially problematic for us because on the channel's `load`, we are fetching the state from MongoDB while actions [are still being processed](https://github.com/logux/server/blob/95166cee9c1da9184a827ed72f343b76be99e021/base-server/index.js#L670) and read into the DB in the background.

# Solution
This PR ensures that we only resubscribe to a channel AFTER everything is synchronized, instead of at the same time the `syncMessage` is being processed.
This might lead to the slightest delay between reconnecting and reloading the state from the channel's `load` - but it's worth it to keep data parity. 