### PR TITLE
use since when creating offline remote filters

### DIFF
--- a/create-filter/index.test.ts
+++ b/create-filter/index.test.ts
@@ -285,7 +285,6 @@ it('does not send since when subscribing to remote stores', async () => {
     authorId: '10'
   })
 
-
   // when creating filter with a matching action in cache
   let filter2 = createFilter(client, Post, { projectId: '10' })
   await client.server.freezeProcessing(async () => {


### PR DESCRIPTION
Creating this PR after discussion with @ai in https://github.com/logux/logux/issues/107. 

I want to minimise data transfer and loading time in a case of large filters for offline and remote stores.

This PR utilises `since` key when creating a filter to only request actions that client has missed. Previously every action was sent from the server on every new subscription (when using `addSyncMapFilter` sugar)