### PR TITLE
Fix StatusListener typing

### DIFF
--- a/status/index.d.ts
+++ b/status/index.d.ts
@@ -4,18 +4,24 @@ import { Client, ClientMeta } from '../client/index.js'
 
 interface StatusListener {
   (
-    ...args:
-      | ['synchronized', void]
-      | ['synchronizedAfterWait', void]
-      | ['disconnected', void]
-      | ['connecting', void]
-      | ['connectingAfterWait', void]
-      | ['protocolError', void]
-      | ['syncError', { error: Error }]
-      | ['error', { action: Action; meta: ClientMeta }]
-      | ['denied', { action: Action; meta: ClientMeta }]
-      | ['wait', void]
-  ): void
+    current:
+      | 'synchronized'
+      | 'synchronizedAfterWait'
+      | 'disconnected'
+      | 'connecting'
+      | 'connectingAfterWait'
+      | 'protocolError'
+      | 'syncError'
+      | 'error'
+      | 'denied'
+      | 'wait',
+    details:
+      | undefined
+      | { error: Error }
+      | {
+      action: Action
+      meta: ClientMeta
+    }  ): void
 }
 
 interface StatusOptions {

--- a/status/index.d.ts
+++ b/status/index.d.ts
@@ -4,24 +4,17 @@ import { Client, ClientMeta } from '../client/index.js'
 
 interface StatusListener {
   (
-    current:
-      | 'synchronized'
-      | 'synchronizedAfterWait'
-      | 'disconnected'
-      | 'connecting'
-      | 'connectingAfterWait'
-      | 'protocolError'
-      | 'syncError'
-      | 'error'
-      | 'denied'
-      | 'wait',
-    details:
-      | undefined
-      | Error
-      | {
-          action: Action
-          meta: ClientMeta
-        }
+    ...args:
+      | ['synchronized', void]
+      | ['synchronizedAfterWait', void]
+      | ['disconnected', void]
+      | ['connecting', void]
+      | ['connectingAfterWait', void]
+      | ['protocolError', void]
+      | ['syncError', { error: Error }]
+      | ['error', { action: Action; meta: ClientMeta }]
+      | ['denied', { action: Action; meta: ClientMeta }]
+      | ['wait', void]
   ): void
 }
 

--- a/status/index.test.ts
+++ b/status/index.test.ts
@@ -198,7 +198,8 @@ it('removes listeners', () => {
   })
 
   let calls = 0
-  let unbind = status(client, state => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let unbind = status(client, (state , details) => {
     if (state === 'denied') {
       calls += 1
     }


### PR DESCRIPTION
Fixed `details` type for `syncError` type and made it more inferring-friendly